### PR TITLE
Add `rootPath` connection setting

### DIFF
--- a/src/acebase-client.ts
+++ b/src/acebase-client.ts
@@ -31,6 +31,12 @@ export class ConnectionSettings {
     https = true;
 
     /**
+     * Root path of the AceBase server instance. Specify this if the server's `rootPath` has been configured.
+     * @default ''
+     */
+    rootPath = '';
+
+    /**
      * Automatically connect to the server, or wait until `db.connect()` is called
      * @default true
      */
@@ -157,6 +163,7 @@ export class ConnectionSettings {
         this.host = settings.host;
         this.port = settings.port;
         this.https = typeof settings.https === 'boolean' ? settings.https : true;
+        if (typeof settings.rootPath === 'string') { this.rootPath = settings.rootPath; }
         this.autoConnect = typeof settings.autoConnect === 'boolean' ? settings.autoConnect : true;
         this.autoConnectDelay = typeof settings.autoConnectDelay === 'number' ? settings.autoConnectDelay : 0;
         this.logLevel = typeof settings.logLevel === 'string' ? settings.logLevel : 'log';
@@ -361,6 +368,7 @@ export class AceBaseClient extends AceBaseBase {
             cache: settings.cache,
             debug: this.debug,
             url: `http${settings.https ? 's' : ''}://${settings.host}:${settings.port}`,
+            rootPath: settings.rootPath,
         }, (evt, data) => {
             if (evt === 'connect') {
                 this.emit('connect');

--- a/src/acebase-client.ts
+++ b/src/acebase-client.ts
@@ -163,7 +163,7 @@ export class ConnectionSettings {
         this.host = settings.host;
         this.port = settings.port;
         this.https = typeof settings.https === 'boolean' ? settings.https : true;
-        if (typeof settings.rootPath === 'string') { this.rootPath = settings.rootPath; }
+        if (typeof settings.rootPath === 'string') { this.rootPath = settings.rootPath.replace(/^\/|\/$/g, ''); }
         this.autoConnect = typeof settings.autoConnect === 'boolean' ? settings.autoConnect : true;
         this.autoConnectDelay = typeof settings.autoConnectDelay === 'number' ? settings.autoConnectDelay : 0;
         this.logLevel = typeof settings.logLevel === 'string' ? settings.logLevel : 'log';

--- a/src/api-web.ts
+++ b/src/api-web.ts
@@ -202,7 +202,7 @@ export class WebApi extends Api {
     constructor(
         private dbname = 'default',
         private settings:
-            Pick<ConnectionSettings, 'network' | 'sync' | 'logLevel' | 'autoConnect' | 'autoConnectDelay' | 'cache'>
+            Pick<ConnectionSettings, 'network' | 'sync' | 'logLevel' | 'autoConnect' | 'autoConnectDelay' | 'cache' | 'rootPath'>
             & { debug: DebugLogger, url: string },
         callback: (event: string, ...args: any[]) => void,
     ) {
@@ -348,6 +348,7 @@ export class WebApi extends Api {
 
             const socket = this.socket = connectSocket(this.url, {
                 // Use default socket.io connection settings:
+                path: this.settings.rootPath + '/socket.io',
                 autoConnect: true,
                 reconnection: retry,
                 reconnectionAttempts: retry ? Infinity : 0,

--- a/src/api-web.ts
+++ b/src/api-web.ts
@@ -172,7 +172,8 @@ export class WebApi extends Api {
 
     private _eventTimeline = { init: Date.now(), connect: 0, signIn: 0, sync: 0, disconnect: 0 };
 
-    public get url() { return this.settings.url; }
+    public get host() { return this.settings.url; }
+    public get url() { return `${this.settings.url}${this.settings.rootPath ? `/${this.settings.rootPath}` : ''}`; }
 
     private async _updateCursor (cursor: string | null) {
         if (!cursor || (this._cursor.current && cursor < this._cursor.current)) {
@@ -346,9 +347,9 @@ export class WebApi extends Api {
                 return setTimeout(() => this.checkConnection(), 0);
             }
 
-            const socket = this.socket = connectSocket(this.url, {
+            const socket = this.socket = connectSocket(this.host, {
                 // Use default socket.io connection settings:
-                path: this.settings.rootPath + '/socket.io',
+                path: `/${this.settings.rootPath ? `${this.settings.rootPath}/` : ''}socket.io`,
                 autoConnect: true,
                 reconnection: retry,
                 reconnectionAttempts: retry ? Infinity : 0,


### PR DESCRIPTION
Enables clients to connect to an AceBase server configured to run on a specific `rootPath`