### PR TITLE
Feature: "warn only" schema definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.20.1",
       "license": "MIT",
       "dependencies": {
-        "acebase-core": "^1.25.1",
+        "acebase-core": "^1.27.1",
         "socket.io-client": "^2.5.0"
       },
       "devDependencies": {
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/acebase-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.1.tgz",
-      "integrity": "sha512-n7iAAMAgO9+WQfYY6Gp+No74iphFfuaP+A/jCw9q8129ebL3KBR41cYykblxUz6Z1KyniQgbYAIptL5IhYeyYw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.27.1.tgz",
+      "integrity": "sha512-+yfjyzSWKLIFNk7PdpER3zK2J8b1C6mxVgnHGM5cjimO244OqDR4IvZ7wAfM88oWqK8AnZ0WhbgVl4xoWsfrhA==",
       "optionalDependencies": {
         "rxjs": ">= 5.x <= 7.x"
       }
@@ -5196,9 +5196,9 @@
       }
     },
     "acebase-core": {
-      "version": "1.26.1",
-      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.26.1.tgz",
-      "integrity": "sha512-n7iAAMAgO9+WQfYY6Gp+No74iphFfuaP+A/jCw9q8129ebL3KBR41cYykblxUz6Z1KyniQgbYAIptL5IhYeyYw==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/acebase-core/-/acebase-core-1.27.1.tgz",
+      "integrity": "sha512-+yfjyzSWKLIFNk7PdpER3zK2J8b1C6mxVgnHGM5cjimO244OqDR4IvZ7wAfM88oWqK8AnZ0WhbgVl4xoWsfrhA==",
       "requires": {
         "rxjs": ">= 5.x <= 7.x"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   "author": "Ewout Stortenbeker <me@appy.one> (http://appy.one)",
   "license": "MIT",
   "dependencies": {
-    "acebase-core": "^1.26.1",
+    "acebase-core": "^1.27.1",
     "socket.io-client": "^2.5.0"
   },
   "devDependencies": {

--- a/src/api-web.ts
+++ b/src/api-web.ts
@@ -2381,11 +2381,11 @@ export class WebApi extends Api {
         return info;
     }
 
-    setSchema(path: string, schema: string | Record<string, any>) {
+    setSchema(path: string, schema: string | Record<string, any>, warnOnly = false) {
         if (schema !== null) {
             schema = (new SchemaDefinition(schema)).text;
         }
-        const data = JSON.stringify({ action: 'set', path, schema });
+        const data = JSON.stringify({ action: 'set', path, schema, warnOnly });
         return this._request({ method: 'POST', url: `${this.url}/schema/${this.dbname}`, data });
     }
 


### PR DESCRIPTION
This enables one to introduce schema definitions to an existing database, but logs warnings instead of denying writes not conforming to the schema.