### PR TITLE
Add network/server related error codes to `isNetworkError` getter, add `isPermissionError`

### DIFF
--- a/src/request/error.ts
+++ b/src/request/error.ts
@@ -5,7 +5,7 @@ export class AceBaseRequestError extends Error {
     }
     get isPermissionError() {
         // 401: Unauthorized, 403: Forbidden
-        return this.response !== null && ([401, 403] as typeof this.code[]).includes(this.code);
+        return this.response !== null && ([401, 403]).some((code) => [this.response?.statusCode, this.code].includes(code));
     }
     constructor(public request: any, public response: any, public code?: number | string, public message: string = 'unknown error') {
         super(message);

--- a/src/request/error.ts
+++ b/src/request/error.ts
@@ -1,6 +1,11 @@
 export class AceBaseRequestError extends Error {
     get isNetworkError() {
-        return this.response === null;
+        // 408: Request Timeout, 429: Too Many Requests, 500: Internal Server Error, 502: Bad Gateway, 503: Service Unavailable, 504: Gateway Timeout
+        return this.response === null || [408, 429, 500, 502, 503, 504].includes(this.code as number);
+    }
+    get isPermissionError() {
+        // 401: Unauthorized, 403: Forbidden
+        return this.response !== null && ([401, 403] as typeof this.code[]).includes(this.code);
     }
     constructor(public request: any, public response: any, public code?: number | string, public message: string = 'unknown error') {
         super(message);

--- a/src/request/error.ts
+++ b/src/request/error.ts
@@ -1,7 +1,7 @@
 export class AceBaseRequestError extends Error {
     get isNetworkError() {
         // 408: Request Timeout, 429: Too Many Requests, 500: Internal Server Error, 502: Bad Gateway, 503: Service Unavailable, 504: Gateway Timeout
-        return this.response === null || [408, 429, 500, 502, 503, 504].includes(this.code as number);
+        return this.response === null || [408, 429, 500, 502, 503, 504].some((code) => [this.response?.statusCode, this.code].includes(code));
     }
     get isPermissionError() {
         // 401: Unauthorized, 403: Forbidden


### PR DESCRIPTION
This causes the client to store a pending mutation to the cache database if it possible to retry the operation because of network issues and/or temporary server processing errors. This also allows other code to decide if a mutation should be rolled back or not.