### PR TITLE
Split `isNetworkError` and `isServerError` up for better handling

### DIFF
--- a/src/api-web.ts
+++ b/src/api-web.ts
@@ -1677,9 +1677,9 @@ export class WebApi extends Api {
 
         Promise.all([ tryCachePromise, tryServerPromise ])
             .then(([ cacheResult, serverResult ]) => {
-                const networkError = serverPromise && !serverResult?.success && serverResult?.error?.isNetworkError === true;
-                if (serverPromise && !networkError) {
-                    // Server update succeeded, or failed with a non-network related reason
+                const retryableError = serverPromise && !serverResult?.success && (serverResult?.error?.isNetworkError === true || serverResult?.error?.isServerError === true);
+                if (serverPromise && !retryableError) {
+                    // Server update succeeded, or failed with a non-network/server related reason
 
                     if (serverResult?.success) {
                         // Server update success
@@ -1849,9 +1849,9 @@ export class WebApi extends Api {
 
         Promise.all([ tryCachePromise, tryServerPromise ])
             .then(([ cacheResult, serverResult ]) => {
-                const networkError = serverResult.executed && !serverResult.success && serverResult.error.isNetworkError === true;
-                if (serverResult.executed && !networkError) {
-                    // Server update succeeded, or failed with a non-network related reason
+                const retryableError = serverPromise && !serverResult?.success && (serverResult?.error?.isNetworkError === true || serverResult?.error?.isServerError === true);
+                if (serverResult.executed && !retryableError) {
+                    // Server update succeeded, or failed with a non-network/server related reason
 
                     if (serverResult.success) {
                         // Server update success
@@ -2039,7 +2039,7 @@ export class WebApi extends Api {
                             return reject(new CachedValueUnavailableError(path));
                         }
                         // Could not get server value because of a non-network related issue - possibly unauthorized access
-                        const error = new CachedValueUnavailableError(path, `Value for "${path}" not found in cache, and server value could not be loaded. See serverError for more details`);
+                        const error = new CachedValueUnavailableError(path, `Value for "${path}" not found in cache, and server value could not be loaded because of error ${serverError.code}: ${serverError.message}`);
                         error.serverError = serverError;
                         return reject(error);
                     }

--- a/src/request/error.ts
+++ b/src/request/error.ts
@@ -1,7 +1,11 @@
 export class AceBaseRequestError extends Error {
     get isNetworkError() {
+        // No response: network error, or blocked by the browser because of incorrect CORS settings
+        return this.response === null;
+    }
+    get isServerError() {
         // 408: Request Timeout, 429: Too Many Requests, 500: Internal Server Error, 502: Bad Gateway, 503: Service Unavailable, 504: Gateway Timeout
-        return this.response === null || [408, 429, 500, 502, 503, 504].some((code) => [this.response?.statusCode, this.code].includes(code));
+        return this.response !== null && [408, 429, 500, 502, 503, 504].some((code) => [this.response?.statusCode, this.code].includes(code));
     }
     get isPermissionError() {
         // 401: Unauthorized, 403: Forbidden


### PR DESCRIPTION
Inclusion of the error code responses into `isNetworkError` created unwanted side effects, so I decided to move them to `isServerError` to handle them separately. These 2 combined are now "retryable errors"